### PR TITLE
Dynamic library

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Compile Vili
       run: cd build; cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON ..; make -j8
     - name: Run tests
-      run: cd build; ./tests/vili_tests
+      run: cd build; ./bin/vili_tests
 
   build_windows:
     name: Build Vili on Windows
@@ -44,7 +44,7 @@ jobs:
     - name: Compile Vili
       run: cmake --build build --config Release -- /m:8
     - name: Run tests
-      run: ./build/tests/Release/vili_tests.exe
+      run: ./build/bin-Release/vili_tests.exe
 
   build_macos:
     name: Build Vili on MacOS
@@ -61,4 +61,4 @@ jobs:
     - name: Compile Vili
       run: cd build && make -j8
     - name: Run tests
-      run: cd build; ./tests/vili_tests
+      run: cd build; ./bin/vili_tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,25 @@ project(vili
     LANGUAGES "CXX"
 )
 
+if(PROJECT_IS_TOP_LEVEL)
+    #Make sure that build outputs are in predictable directories
+    #This is to ensure that the DLLs are in the same directory as the test, so the tests can run
+    get_property(IS_MULTI_CONFIG GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+    if(IS_MULTI_CONFIG)
+        foreach(CONFIG_TYPE IN ITEMS ${CMAKE_CONFIGURATION_TYPES})
+            string(TOUPPER "${CONFIG_TYPE}" UPPERCASE_CONFIG_TYPE)
+            set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_${UPPERCASE_CONFIG_TYPE} "${CMAKE_BINARY_DIR}/bin-${CONFIG_TYPE}")
+            set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY_${UPPERCASE_CONFIG_TYPE} "${CMAKE_BINARY_DIR}/lib-${CONFIG_TYPE}")
+            set(CMAKE_LIBRARY_OUTPUT_DIRECTORY_${UPPERCASE_CONFIG_TYPE} "${CMAKE_BINARY_DIR}/lib-${CONFIG_TYPE}")
+        endforeach()
+    else()
+        set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
+        set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib")
+        set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib")
+    endif()
+endif()
+
+
 set(VILI_HEADERS
     include/vili/config.hpp
     include/vili/exceptions.hpp
@@ -49,10 +68,10 @@ find_package(fmt CONFIG REQUIRED)
 find_package(nlohmann-fifo-map CONFIG REQUIRED)
 find_package(pegtl CONFIG REQUIRED)
 
-target_link_libraries(vili PRIVATE
-    fmt::fmt
-    nlohmann-fifo-map::nlohmann-fifo-map
-    taocpp::pegtl
+target_link_libraries(vili
+    PUBLIC fmt::fmt
+    PUBLIC nlohmann-fifo-map::nlohmann-fifo-map
+    PUBLIC taocpp::pegtl
 )
 
 set_target_properties(vili
@@ -61,13 +80,20 @@ set_target_properties(vili
         CXX_STANDARD_REQUIRED ON
         CXX_EXTENSIONS OFF
         DEBUG_POSTFIX "d"
+        VERSION "${PROJECT_VERSION}"
+        SOVERSION "${PROJECT_VERSION_MAJOR}"
 )
 
-if(NOT DEFINED BUILD_TESTS)
-    set(BUILD_TESTS OFF CACHE BOOL "Build Vili Tests ?")
+option(BUILD_SHARED_LIBS "Build Vili as a dynamic library?" OFF)
+if(BUILD_SHARED_LIBS)
+    set_target_properties(vili
+        PROPERTIES
+            WINDOWS_EXPORT_ALL_SYMBOLS ON
+    )
 endif()
 
-if(BUILD_TESTS)
+option(BUILD_TESTS "Build Vili Tests?" OFF)
+if(BUILD_TESTS AND PROJECT_IS_TOP_LEVEL)
     add_subdirectory(tests)
 endif()
 

--- a/include/vili/node.hpp
+++ b/include/vili/node.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <iostream>
 #include <string>
 #include <string_view>
@@ -264,13 +265,13 @@ namespace vili
          * \param index index of the children to access
          * \return reference to the children at given index
          */
-        node& operator[](size_t index);
+        node& operator[](uint64_t index);
         /**
          * \brief Access element at given index
          * \param index index of the children to access
          * \return reference to the children at given index
          */
-        node& operator[](unsigned int index);
+        node& operator[](uint32_t index);
         /**
          * \brief Access element at given key
          * \param key key of the children to access
@@ -288,7 +289,13 @@ namespace vili
          * \param index index of the children to access
          * \return reference to the children at given index
          */
-        const node& operator[](size_t index) const;
+        const node& operator[](uint64_t index) const;
+        /**
+         * \brief Access element at given index
+         * \param index index of the children to access
+         * \return reference to the children at given index
+         */
+        const node& operator[](uint32_t index) const;
 
         void push(const node& value);
         /**

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -392,12 +392,12 @@ namespace vili
         throw exceptions::invalid_cast(object_typename, to_string(type()), VILI_EXC_INFO);
     }
 
-    node& node::operator[](const size_t index)
+    node& node::operator[](uint64_t index)
     {
         return this->at(index);
     }
 
-    node& node::operator[](unsigned int index)
+    node& node::operator[](uint32_t index)
     {
         return this->at(index);
     }
@@ -412,7 +412,12 @@ namespace vili
         return this->at(key);
     }
 
-    const node & node::operator[](size_t index) const
+    const node & node::operator[](uint64_t index) const
+    {
+        return this->at(index);
+    }
+
+    const node & node::operator[](uint32_t index) const
     {
         return this->at(index);
     }


### PR DESCRIPTION
As promised, I have attempted to port this library to vcpkg: microsoft/vcpkg#27839
The good news that it works for all the static triplets.
The bad news that it doesn't work for the dynamic triplets.

So this makes sure that the DLL builds correctly.
As executables in windows lack rpaths, the test executable and DLLs are now placed in the same build directory.
The CI needed to be changed to reflect the changed test binary directory.
The SOVERSION property is set for linux dynamic libraries.

Note that the option BUILD_SHARED_LIBS is still off by default, as this library is intended to be a static library.

Also there's a commit to fix this for 32-bit builds.

